### PR TITLE
Make sure CPUs for(..in..) loops only on own CPU data

### DIFF
--- a/lib/osutils.js
+++ b/lib/osutils.js
@@ -196,7 +196,7 @@ function getCPUInfo(callback){
     var total = 0;
 	
     for(var cpu in cpus){
-		
+        if (!cpus.hasOwnProperty(cpu)) continue;	
         user += cpus[cpu].times.user;
         nice += cpus[cpu].times.nice;
         sys += cpus[cpu].times.sys;


### PR DESCRIPTION
> See http://stackoverflow.com/questions/2040042/javascript-array-iteration-using-for-in-with-mootools-included

I was having troubles with `cpuUsage()` until I found out removing Mootools lib removes the problem. I think the fix is ok and not strictly Mootools related, as any script that inject extra properties in the Array prototype would have break it.
