### PR TITLE
Milliseconds to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ os.freememPercentage()
 ```
 
 
-### Get the number of miliseconds the system has been running for
+### Get the number of seconds the system has been running for
 ```js
 os.sysUptime();
 ```
 	
 	
-### Get the number of miliseconds the process has been running
+### Get the number of seconds the process has been running
 ```js
 os.processUptime() 
 ```


### PR DESCRIPTION
Fix for issue #6. The uptime is returned in seconds instead of milliseconds.